### PR TITLE
Fix typos

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,10 @@
   "cSpell.words": [
     "Dexmedetomidine",
     "Immunofluorescence",
-    "Immunohistochemistry"
+    "Immunohistochemistry",
+    "Intracerebral",
+    "isoflurane",
+    "rotarod",
+    "wirehang"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "cSpell.words": [
+    "Analglesia",
     "Dexmedetomidine",
     "Immunofluorescence",
     "Immunohistochemistry",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "cSpell.words": [
-    "Analglesia",
+    "analgesia",
     "Dexmedetomidine",
     "Immunofluorescence",
     "Immunohistochemistry",

--- a/lib/forms/CoBrALab-Mouse-End-Of-Life-Form/index.ts
+++ b/lib/forms/CoBrALab-Mouse-End-Of-Life-Form/index.ts
@@ -23,7 +23,7 @@ export default defineInstrument({
   language: 'en',
   tags: ['End of Life', 'Mouse', 'Euthanasia', 'Termination'],
   internal: {
-    edition: 1,
+    edition: 2,
     name: 'MOUSE_END_OF_LIFE_FORM'
   },
   content: {

--- a/lib/forms/CoBrALab-Mouse-End-Of-Life-Form/index.ts
+++ b/lib/forms/CoBrALab-Mouse-End-Of-Life-Form/index.ts
@@ -240,7 +240,7 @@ export default defineInstrument({
                 options: {
                   "Ethanol": 'Ethanol 70%',
                   'Sodium Alzide': 'Sodium Alzide',
-                  'Gadolum Bath': 'Gadolum Bath',
+                  'Gadolinium Bath': 'Gadolinium Bath',
                   "None": 'None'
                 }
               },
@@ -392,7 +392,7 @@ export default defineInstrument({
           bodyPartStorageSolution: z.enum([
           'Ethanol',
           'Sodium Alzide',
-          'Gadolum Bath',
+          'Gadolinium Bath',
           'None'
         ]),
           bodyPartStorageLocation: z.enum([

--- a/lib/forms/CoBrALab-Mouse-Injection-Form/index.ts
+++ b/lib/forms/CoBrALab-Mouse-Injection-Form/index.ts
@@ -23,7 +23,7 @@ export default defineInstrument({
   language: 'en',
   tags: ['Injections', 'Drug', 'Physical Intervention','Anesthesia'],
   internal: {
-    edition: 1,
+    edition: 2,
     name: 'MOUSE_INJECTIONS_FORM'
   },
   content: {

--- a/lib/forms/CoBrALab-Mouse-Injection-Form/index.ts
+++ b/lib/forms/CoBrALab-Mouse-Injection-Form/index.ts
@@ -116,8 +116,8 @@ export default defineInstrument({
             variant: "select",
             label: "Analgesic type",
             options: {
-              "Carpofem": "Carpofem",
-              "Buvicane": "Buvicane"
+              "Carprofen": "Carprofen",
+              "Bupivacaine": "Bupivacaine"
             }
           }
         }
@@ -224,7 +224,7 @@ export default defineInstrument({
     subcutaneousInjectionType: z.enum(["Analgesic", "Other"]).optional(),
     subcutaneousInjectionTime: z.enum(["During operation", "Post operation"]).optional(),
     postOperationDay: z.date().optional(),
-    analgesicType: z.enum(["Carpofem", "Buvicane"]).optional(),
+    analgesicType: z.enum(["Carprofen", "Bupivacaine"]).optional(),
     ipDoseVolume: z.number().min(0).optional(),
     drugInjected: z.enum(["PU-AD", "PU-AD Vehicle", "IP Tamoxifen", "STZ"]).optional(),
     ipInjectionType: z.enum(["Viral memetic", "Anesthetic"]).optional()

--- a/lib/forms/CoBrALab-Mouse-MRI-Form/index.ts
+++ b/lib/forms/CoBrALab-Mouse-MRI-Form/index.ts
@@ -26,7 +26,7 @@ export default defineInstrument({
   language: 'en',
   tags: ['Mouse', 'MRI', 'Structural', 'fMRI'],
   internal: {
-    edition: 1,
+    edition: 2,
     name: 'MOUSE_MRI_FORM'
   },
   content: {

--- a/lib/forms/CoBrALab-Mouse-MRI-Form/index.ts
+++ b/lib/forms/CoBrALab-Mouse-MRI-Form/index.ts
@@ -206,7 +206,7 @@ export default defineInstrument({
       }
     },
 
-    isofluoraneUsed: {
+    isofluraneUsed: {
       kind: "dynamic",
       deps: ["anestheticUsed"],
       render(data) {
@@ -214,7 +214,7 @@ export default defineInstrument({
           return {
             kind: "boolean",
             variant: "radio",
-            label: "Isofluorane used?"
+            label: "Isoflurane used?"
           }
         }
         return null
@@ -222,15 +222,15 @@ export default defineInstrument({
 
     },
 
-    isofluoraneBottleSerialCode: {
+    isofluraneBottleSerialCode: {
       kind: "dynamic",
-      deps: ['isofluoraneUsed'],
+      deps: ['isofluraneUsed'],
       render(data) {
-        if (data.isofluoraneUsed) {
+        if (data.isofluraneUsed) {
           return {
             kind: 'string',
             variant: "input",
-            label: "Isofluorane bottle code"
+            label: "Isoflurane bottle code"
           }
         }
         return null
@@ -238,45 +238,45 @@ export default defineInstrument({
     },
 
 
-    isofluoraneAdjustedFromSOP: {
+    isofluraneAdjustedFromSOP: {
       kind: "dynamic",
-      deps: ['isofluoraneUsed'],
+      deps: ['isofluraneUsed'],
       render(data) {
-        if (data.isofluoraneUsed) {
+        if (data.isofluraneUsed) {
           return {
             kind: 'boolean',
             variant: "radio",
-            label: "Isofluorane adjusted from SOP?"
+            label: "Isoflurane adjusted from SOP?"
           }
         }
         return null
       }
     },
 
-    isofluoraneAdjustedPercentage: {
+    isofluraneAdjustedPercentage: {
       kind: "dynamic",
-      deps: ['isofluoraneAdjustedFromSOP'],
+      deps: ['isofluraneAdjustedFromSOP'],
       render(data) {
-        if (data.isofluoraneAdjustedFromSOP) {
+        if (data.isofluraneAdjustedFromSOP) {
           return {
             kind: "string",
             variant: "input",
-            label: "Isofluorane percentage",
+            label: "Isoflurane percentage",
           }
         }
         return null
       }
     },
 
-    fmriIsofluoraneTracked: {
+    fmriIsofluraneTracked: {
       kind: "dynamic",
-      deps: ['isofluoraneUsed'],
+      deps: ['isofluraneUsed'],
       render(data) {
-        if(data.isofluoraneUsed){
+        if(data.isofluraneUsed){
           return {
             kind: "boolean",
             variant: "radio",
-            label: "fMRI isofluorane levels tracked?"
+            label: "fMRI isoflurane levels tracked?"
           }
         }
         return null
@@ -284,15 +284,15 @@ export default defineInstrument({
       
     },
 
-    fmriIsofluorane: {
+    fmriIsoflurane: {
       kind: "dynamic",
-      deps: ['fmriIsofluoraneTracked'],
+      deps: ['fmriIsofluraneTracked'],
       render(data) {
-        if (data.fmriIsofluoraneTracked) {
+        if (data.fmriIsofluraneTracked) {
           return {
             kind: "number",
             variant: "slider",
-            label: "fMRI Isofluorane percentage, consider this as the value before it is divised by 10, i.e. 15 = 1.5%",
+            label: "fMRI Isoflurane percentage, consider this as the value before it is divided by 10, i.e. 15 = 1.5%",
             max: 15,
             min: 0
           }
@@ -300,15 +300,15 @@ export default defineInstrument({
         return null
       }
     },
-    fmriIsofluoraneColour: {
+    fmriIsofluraneColour: {
       kind: "dynamic",
-      deps: ['fmriIsofluorane'],
+      deps: ['fmriIsoflurane'],
       render(data) {
-        if (data.fmriIsofluorane === 2) {
+        if (data.fmriIsoflurane === 2) {
           return {
             kind: "string",
             variant: "radio",
-            label: "Isofluorane colour code",
+            label: "Isoflurane colour code",
             options: {
               "yellow": "Yellow",
               "green": "Green"
@@ -425,7 +425,7 @@ export default defineInstrument({
             otherComments: {
               kind: "string",
               variant: "textarea",
-              label: "Please write any additonal comments/notes here"
+              label: "Please write any additional comments/notes here"
             }
           }
         }
@@ -479,33 +479,33 @@ export default defineInstrument({
       kind: "const",
       ref: "dexBottleSerialCode"
     },
-    isofluoraneUsed: {
+    isofluraneUsed: {
       kind: "const",
-      ref: "isofluoraneUsed"
+      ref: "isofluraneUsed"
     },
-    isofluoraneBottleSerialCode: {
+    isofluraneBottleSerialCode: {
       kind: "const",
-      ref: "isofluoraneBottleSerialCode"
+      ref: "isofluraneBottleSerialCode"
     },
-    isofluoraneAdjustedFromSOP: {
+    isofluraneAdjustedFromSOP: {
       kind: "const",
-      ref: "isofluoraneAdjustedFromSOP"
+      ref: "isofluraneAdjustedFromSOP"
     },
-    isofluoraneAdjustedPercentage: {
+    isofluraneAdjustedPercentage: {
       kind: "const",
-      ref: "isofluoraneAdjustedPercentage"
+      ref: "isofluraneAdjustedPercentage"
     },
-    fmriIsofluoraneTracked: {
+    fmriIsofluraneTracked: {
       kind: "const",
-      ref: "fmriIsofluoraneTracked"
+      ref: "fmriIsofluraneTracked"
     },
-    fmriIsofluorane: {
+    fmriIsoflurane: {
       kind: "const",
-      ref: "fmriIsofluorane"
+      ref: "fmriIsoflurane"
     },
-    fmriIsofluoraneColour: {
+    fmriIsofluraneColour: {
       kind: "const",
-      ref: "fmriIsofluoraneColour"
+      ref: "fmriIsofluraneColour"
     },
     scanRecordInfo: {
       kind: "computed",
@@ -548,13 +548,13 @@ export default defineInstrument({
     dexBottleSerialCode: z.string().optional(),
     dexAdjustedFromSOP: z.boolean().optional(),
     dexAdjustedPercentage: z.string().optional(),
-    isofluoraneUsed: z.boolean(),
-    isofluoraneBottleSerialCode: z.string().optional(),
-    isofluoraneAdjustedFromSOP: z.boolean().optional(),
-    isofluoraneAdjustedPercentage: z.string().optional(),
-    fmriIsofluoraneTracked: z.boolean().optional(),
-    fmriIsofluorane: z.number().optional(),
-    fmriIsofluoraneColour: z.enum(['yellow', 'green']).optional(),
+    isofluraneUsed: z.boolean(),
+    isofluraneBottleSerialCode: z.string().optional(),
+    isofluraneAdjustedFromSOP: z.boolean().optional(),
+    isofluraneAdjustedPercentage: z.string().optional(),
+    fmriIsofluraneTracked: z.boolean().optional(),
+    fmriIsoflurane: z.number().optional(),
+    fmriIsofluraneColour: z.enum(['yellow', 'green']).optional(),
     scanRecordInfo: z.array(z.object({
       mriScanName: z.enum([
         "Localizer",

--- a/lib/forms/CoBrALab-Mouse-Surgery-Form/index.ts
+++ b/lib/forms/CoBrALab-Mouse-Surgery-Form/index.ts
@@ -23,7 +23,7 @@ export default defineInstrument({
   language: 'en',
   tags: ['Surgery', 'Vet Care', 'Wound Treatment', 'Ovariectomy'],
   internal: {
-    edition: 1,
+    edition: 2,
     name: 'MOUSE_SURGERY_FORM'
   },
   content: {

--- a/lib/forms/CoBrALab-Mouse-Surgery-Form/index.ts
+++ b/lib/forms/CoBrALab-Mouse-Surgery-Form/index.ts
@@ -36,35 +36,35 @@ export default defineInstrument({
         "Wound treatment": "Wound treatment"
       }
     },
-    aneglesiaUsed: createDependentField({
+    analglesiaUsed: createDependentField({
       kind: "boolean",
       variant: "radio",
-      label: "Aneglesia used"
+      label: "Analglesia used"
     }, (type) => type === "Surgery"),
 
-    aneglesiaType: {
+    analglesiaType: {
       kind: "dynamic",
-      deps: ["aneglesiaUsed"],
+      deps: ["analglesiaUsed"],
       render(data) {
-        if(data.aneglesiaUsed){
+        if(data.analglesiaUsed){
           return {
             kind: "string",
             variant: "input",
-            label: "Aneglesia type"
+            label: "Analglesia type"
           }
         }
         return null
       }
     },
-    aneglesiaVolume: {
+    analglesiaVolume: {
        kind: "dynamic",
-       deps: ["aneglesiaUsed"],
+       deps: ["analglesiaUsed"],
        render(data) {
-        if(data.aneglesiaUsed){
+        if(data.analglesiaUsed){
           return {
           kind: "number",
           variant: "input",
-          label: "Aneglesia volume (ml)"
+          label: "Analglesia volume (ml)"
           }
         }
         return null
@@ -236,17 +236,17 @@ export default defineInstrument({
       label: "Selected physical intervention",
       ref: "treatmentType"
     },
-    aneglesiaUsed: {
+    analglesiaUsed: {
       kind: "const",
-      ref: "aneglesiaUsed"
+      ref: "analglesiaUsed"
     },
-    aneglesiaType: {
+    analglesiaType: {
       kind: "const",
-      ref: "aneglesiaType"
+      ref: "analglesiaType"
     },
-    aneglesiaVolume: {
+    analglesiaVolume: {
       kind: "const",
-      ref: "aneglesiaVolume"
+      ref: "analglesiaVolume"
     },
     stereotaxUsed: {
       kind: "const",
@@ -299,9 +299,9 @@ export default defineInstrument({
   },
   validationSchema: z.object({
       treatmentType: z.enum(["Surgery", "Wound treatment"]),
-      aneglesiaUsed: z.boolean().optional(),
-      aneglesiaType: z.string().optional(),
-      aneglesiaVolume: z.number().min(0).optional(),
+      analglesiaUsed: z.boolean().optional(),
+      analglesiaType: z.string().optional(),
+      analglesiaVolume: z.number().min(0).optional(),
       stereotaxUsed: z.boolean().optional(),
       stereotaxId: z.string().optional(),
       surgeryType: z.enum(["Ovariectomy", "Electrode implant", "Fiber optic implant"]).optional(),

--- a/lib/forms/CoBrALab-Stress-Administration-Form/index.ts
+++ b/lib/forms/CoBrALab-Stress-Administration-Form/index.ts
@@ -58,10 +58,10 @@ export default defineInstrument({
       label: "Number of foot shocks"
     }, (type) => type === "Electric foot shocks"),
 
-    footShockAmpage: createDependentField({
+    footShockAmperage: createDependentField({
       kind: "number",
       variant: "input",
-      label: "Electric shock ampage (in milliamps)"
+      label: "Electric shock amperage (in milliamps)"
     },
     (type) => type === "Electric foot shocks"),
     
@@ -98,9 +98,9 @@ export default defineInstrument({
         kind: "const",
         ref: "footShocksNumber"
       },
-      footShockAmpage: {
+      footShockAmperage: {
         kind: "const",
-        ref: "footShockAmpage"
+        ref: "footShockAmperage"
       },
       tailSuspensionClimbStoppers: {
         kind: "const",
@@ -112,7 +112,7 @@ export default defineInstrument({
     roomNumber: z.string(),
     stressorType: z.enum(["Electric foot shocks", "Tail suspension", "Restraint"]),
     footShocksNumber: z.number().int().min(1).optional(),
-    footShockAmpage: z.number().min(0).optional(),
+    footShockAmperage: z.number().min(0).optional(),
     tailSuspensionClimbStoppers: z.boolean().optional()
 
   })

--- a/lib/forms/CoBraLab-Mouse-Touchscreen-Form/index.ts
+++ b/lib/forms/CoBraLab-Mouse-Touchscreen-Form/index.ts
@@ -198,7 +198,7 @@ export default defineInstrument({
     },
     trialFailed: {
       kind: 'const',
-      label: 'Trail failed',
+      label: 'Trial failed',
       ref: "trialFailed"
     },
     failureReason: {

--- a/lib/forms/CoBraLab-Mouse-Touchscreen-Form/index.ts
+++ b/lib/forms/CoBraLab-Mouse-Touchscreen-Form/index.ts
@@ -8,7 +8,7 @@ export default defineInstrument({
   language: 'en',
   tags: ['Mouse, Touchscreen','PVD','5-choice'],
   internal: {
-    edition: 1,
+    edition: 2,
     name: 'MOUSE_TOUCHSCREEN_FORM'
   },
   content: {

--- a/lib/forms/CoBraLab-Mouse-Touchscreen-Form/index.ts
+++ b/lib/forms/CoBraLab-Mouse-Touchscreen-Form/index.ts
@@ -29,7 +29,7 @@ export default defineInstrument({
         "habituation":"Habituation",
         "habituation2a":"Habituation2a",
         "habituation2b":"Habituation2b",
-        "intial touch": "Initial touch",
+        "initial touch": "Initial touch",
         "must touch": "Must touch",
         "must initiate": "Must initiate",
         "punish incorrect":"Punish incorrect",
@@ -46,7 +46,7 @@ export default defineInstrument({
             variant: 'radio',
             label: "PVD experiment stage",
             options: {
-              "aquisition": "Aquisition",
+              "acquisition": "Acquisition",
               "reversal":"Reversal",
               "re-reversal": "Re-reversal"
             }
@@ -214,13 +214,13 @@ export default defineInstrument({
     "habituation",
     "habituation2a",
     "habituation2b",
-    "intial touch",
+    "initial touch",
     "must touch",
     "must initiate",
     "punish incorrect",
     "full session"
   ]),
-  pvdStage: z.enum(["aquisition", "reversal", "re-reversal"]).optional(),
+  pvdStage: z.enum(["acquisition", "reversal", "re-reversal"]).optional(),
   fiveChoiceStage: z.enum(["4 second stimulus", "2 second stimulus", "Pro trial"]).optional(),
   chamberNumber: z.number().min(1).max(12),
   chamberSerialCode: z.string(),


### PR DESCRIPTION
closes issue #54 

fixes typos in all main branch forms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Bug Fixes**
	- Corrected spelling of various terms across multiple forms, including:
		- "Gadolinium Bath" in End-of-Life Form
		- "Carprofen" and "Bupivacaine" in Injection Form
		- "Isoflurane" in MRI Form
		- "Analgesia" in Surgery Form
		- "Amperage" in Stress Administration Form
		- "Initial touch" and "Acquisition" in Touchscreen Form

- **Chores**
	- Updated VSCode spell-check dictionary with new scientific and technical terms
	- Added new terms to the spell-check dictionary, including "analgesia," "intracerebral," "isoflurane," "rotarod," and "wirehang."
	- Incremented internal edition numbers across multiple forms from 1 to 2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->