### PR TITLE
Burying task related behaviour test forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 	  "typescript": "~5.7.2",
-	  "vite": "^6.2.0"
+	  "vite": ">=6.2.3"
 	},
 	"dependencies": {
 	  "gh-pages": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
-	"name": "mouse-form-viewer",
-	"homepage": "https://CoBrALab.github.io/ODC-Mouse-Forms/",
-	"private": true,
-	"version": "0.0.0",
-	"type": "module",
-	"scripts": {
-	  "dev": "vite",
-	  "build": "tsc && vite build",
-	  "preview": "vite preview",
-      "setup-pages": "pnpm build && gh-pages -d dist"
-	},
-	"devDependencies": {
-	  "typescript": "~5.7.2",
-	  "vite": ">=6.2.3"
-	},
-	"dependencies": {
-	  "gh-pages": "^6.3.0",
-	  "lz-string": "^1.5.0"
-	},
-	"packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
-  }
+  "name": "mouse-form-viewer",
+  "homepage": "https://CoBrALab.github.io/ODC-Mouse-Forms/",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "setup-pages": "pnpm build && gh-pages -d dist"
+  },
+  "devDependencies": {
+    "typescript": "~5.7.2",
+    "vite": ">=6.2.4"
+  },
+  "dependencies": {
+    "gh-pages": "^6.3.0",
+    "lz-string": "^1.5.0"
+  },
+  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ~5.7.2
         version: 5.7.3
       vite:
-        specifier: ^6.2.0
-        version: 6.2.0
+        specifier: '>=6.2.3'
+        version: 6.2.3
 
 packages:
 
@@ -497,8 +497,8 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  vite@6.2.0:
-    resolution: {integrity: sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==}
+  vite@6.2.3:
+    resolution: {integrity: sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -920,7 +920,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  vite@6.2.0:
+  vite@6.2.3:
     dependencies:
       esbuild: 0.25.0
       postcss: 8.5.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ~5.7.2
         version: 5.7.3
       vite:
-        specifier: '>=6.2.3'
-        version: 6.2.3
+        specifier: '>=6.2.4'
+        version: 6.2.4
 
 packages:
 
@@ -497,8 +497,8 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  vite@6.2.3:
-    resolution: {integrity: sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==}
+  vite@6.2.4:
+    resolution: {integrity: sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -920,7 +920,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  vite@6.2.3:
+  vite@6.2.4:
     dependencies:
       esbuild: 0.25.0
       postcss: 8.5.3

--- a/public/forms/CoBraLab-Behavioural-Experiment-form/index.ts
+++ b/public/forms/CoBraLab-Behavioural-Experiment-form/index.ts
@@ -6,7 +6,7 @@ const { z } = await import('/runtime/v1/zod@3.23.x/index.js');
 export default defineInstrument({
   kind: 'FORM',
   language: 'en',
-  tags: ['Mouse', 'Marble burying', 'Scale'],
+  tags: ['Mouse', 'Marble burying', 'MRI Habituation', 'Odour task', 'Food Burying', 'Ultrasonic Vocalization'],
   internal: {
     edition: 1,
     name: 'MOUSE_BEHAVIOURAL_FORM'

--- a/public/forms/CoBraLab-Behavioural-Experiment-form/index.ts
+++ b/public/forms/CoBraLab-Behavioural-Experiment-form/index.ts
@@ -1,0 +1,42 @@
+/* eslint-disable perfectionist/sort-objects */
+
+const { defineInstrument } = await import('/runtime/v1/@opendatacapture/runtime-core/index.js');
+const { z } = await import('/runtime/v1/zod@3.23.x/index.js');
+
+export default defineInstrument({
+  kind: 'FORM',
+  language: 'en',
+  tags: ['Mouse', 'Marble burying', 'Scale'],
+  internal: {
+    edition: 1,
+    name: 'MOUSE_BEHAVIOURAL_FORM'
+  },
+  content: {
+    additionalComments: {
+      kind: "string",
+      variant: "textarea",
+      label: "Additional Comments"
+    }
+  },
+  clientDetails: {
+    estimatedDuration: 1,
+    instructions: ['To be filled in whenever the animal is weighed. It is expected to know what type of scale is used (portable vs. non-portable) as well as its serial code. It is also assumed that proper weighing protocol is followed']
+  },
+  details: {
+    description: 'A form to track data from whenever an animal is weighed.',
+    license: 'Apache-2.0',
+    title: 'Mouse Behavioral Experiment Form'
+  },
+  measures: {
+   
+    additionalComments: {
+      kind: 'const',
+      visibility: 'visible',
+      ref: 'additionalComments'
+    }
+
+  },
+  validationSchema: z.object({
+    additionalComments: z.string().optional()
+  })
+});

--- a/public/forms/CoBraLab-Burying-Task-form/index.ts
+++ b/public/forms/CoBraLab-Burying-Task-form/index.ts
@@ -6,12 +6,17 @@ const { z } = await import('/runtime/v1/zod@3.23.x/index.js');
 export default defineInstrument({
   kind: 'FORM',
   language: 'en',
-  tags: ['Mouse', 'Marble burying', 'MRI Habituation', 'Odour task', 'Food Burying', 'Ultrasonic Vocalization'],
+  tags: ['Mouse', 'Marble burying', 'Food Burying'],
   internal: {
     edition: 1,
-    name: 'MOUSE_BEHAVIOURAL_FORM'
+    name: 'MOUSE_BURYING_TASK_FORM'
   },
   content: {
+    roomNumber: {
+      kind: 'string',
+      variant: "input",
+      label: "Room number"
+    },
     additionalComments: {
       kind: "string",
       variant: "textarea",
@@ -19,8 +24,8 @@ export default defineInstrument({
     }
   },
   clientDetails: {
-    estimatedDuration: 1,
-    instructions: ['To be filled in whenever the animal is weighed. It is expected to know what type of scale is used (portable vs. non-portable) as well as its serial code. It is also assumed that proper weighing protocol is followed']
+    estimatedDuration: 2,
+    instructions: ['To be filled in whenever the animal completes a burying task. Before the form is used the user must know what item the animal has buried as well as the location the task took place in']
   },
   details: {
     description: 'A form to track data from whenever an animal is weighed.',
@@ -28,6 +33,11 @@ export default defineInstrument({
     title: 'Mouse Behavioral Experiment Form'
   },
   measures: {
+    roomNumber: {
+      kind: 'const',
+      visibility: 'visible',
+      ref: "roomNumber"
+    },
    
     additionalComments: {
       kind: 'const',
@@ -37,6 +47,7 @@ export default defineInstrument({
 
   },
   validationSchema: z.object({
+    roomNumber: z.string(),
     additionalComments: z.string().optional()
   })
 });

--- a/public/forms/CoBraLab-Burying-Task-form/index.ts
+++ b/public/forms/CoBraLab-Burying-Task-form/index.ts
@@ -130,7 +130,7 @@ export default defineInstrument({
     instructions: ['To be filled in whenever the animal completes a burying task. Before the form is used the user must know what item the animal has buried as well as the location the task took place in']
   },
   details: {
-    description: 'A form to track data from whenever an animal is weighed.',
+    description: 'A form to track data from a burying related behavior task given to an animal',
     license: 'Apache-2.0',
     title: 'Mouse Behavioral Experiment Form'
   },

--- a/public/forms/CoBraLab-Burying-Task-form/index.ts
+++ b/public/forms/CoBraLab-Burying-Task-form/index.ts
@@ -50,14 +50,74 @@ export default defineInstrument({
     }, (type) => type === "Marbles"),
     percentageMarblesBuried: createDependentField({
       kind: 'string',
-            variant: "radio",
-            label: "Percentage range of marbles buried",
-            options: {
-              "100 %": "100 %",
-              "100 - 75%": "100 - 75%",
-              "75% - 0%":"75% - 0%"
-            }
+      variant: "radio",
+      label: "Percentage range of marbles buried",
+      options: {
+        "100 %": "100 %",
+        "100 - 75%": "100 - 75%",
+        "75% - 0%":"75% - 0%"
+      }
     },(type) => type === "Marbles"),
+    foodBuryingTimeCutOff: createDependentField({
+      kind: "boolean",
+      variant: "radio",
+      label: "Did the task have a time cut off"
+    }, (type) => type === "Food"),
+
+    foodBuryingTimeCutOffDuration: {
+      kind: "dynamic",
+      deps: ["foodBuryingTimeCutOff"],
+      render(data) {
+        if (data.foodBuryingTimeCutOff){
+          return {
+                kind: "number",
+                variant: "input",
+                label: "Duration of food burying task (seconds)"
+          }
+        }
+        return null
+      }
+    },
+    foodPosition: createDependentField({
+      kind: "string",
+      variant: "input",
+      label: "Food position"
+    }, (type) => type === "Food"),
+
+    ethoVisionUsed: createDependentField({
+      kind: "boolean",
+      variant: "radio",
+      label: "Was Ethovision used for the task?"
+    }, (type) => type === "Food"),
+
+    ethoVisionDistanceTravelled: {
+      kind: "dynamic",
+      deps: ["ethoVisionUsed"],
+      render(data) {
+        if(data.ethoVisionUsed){
+          return {
+            kind: "number",
+            variant: "input",
+            label: "Distance travelled (cm)"
+          }
+        }
+        return null
+      }
+    },
+    ethoVisionLatency: {
+      kind: "dynamic",
+      deps: ["ethoVisionUsed"],
+      render(data) {
+        if(data.ethoVisionUsed){
+          return {
+            kind: "number",
+            variant: "input",
+            label: "Ethovision latency (ms)"
+          }
+        }
+        return null
+      }
+    },
 
     additionalComments: {
       kind: "string",
@@ -95,6 +155,36 @@ export default defineInstrument({
       visibility: 'visible',
       ref: "percentageMarblesBuried"
     },
+    foodBuryingTimeCutOff: {
+    kind: 'const',
+    visibility: 'visible',
+    ref: "foodBuryingTimeCutOff"
+    },
+    foodBuryingTimeCutOffDuration: {
+      kind: 'const',
+      visibility: 'visible',
+      ref: "foodBuryingTimeCutOffDuration"
+    },
+    foodPosition: {
+      kind: 'const',
+      visibility: 'visible',
+      ref: "foodPosition"
+    },
+    ethoVisionUsed: {
+      kind: 'const',
+      visibility: 'visible',
+      ref: "ethoVisionUsed"
+    },
+    ethoVisionDistanceTravelled: {
+      kind: 'const',
+      visibility: 'visible',
+      ref: "ethoVisionDistanceTravelled"
+    },
+    ethoVisionLatency: {
+      kind: 'const',
+      visibility: 'visible',
+      ref: "ethoVisionLatency"
+    },
     additionalComments: {
       kind: 'const',
       visibility: 'visible',
@@ -107,6 +197,12 @@ export default defineInstrument({
     itemBuried: z.enum(["Marbles","Food"]),
     cageNumber: z.string().optional(),
     percentageMarblesBuried: z.enum(["100 %","100 - 75%","75% - 0%"]).optional(),
+    foodBuryingTimeCutOff: z.boolean(),
+    foodBuryingTimeCutOffDuration: z.number().min(0).int().optional(),
+    foodPosition: z.string().optional(),
+    ethoVisionUsed: z.boolean().optional(),
+    ethoVisionDistanceTravelled: z.number().min(0).optional(),
+    ethoVisionLatency: z.number().min(0).optional(),
     additionalComments: z.string().optional()
   })
 });

--- a/public/forms/CoBraLab-Burying-Task-form/index.ts
+++ b/public/forms/CoBraLab-Burying-Task-form/index.ts
@@ -17,6 +17,15 @@ export default defineInstrument({
       variant: "input",
       label: "Room number"
     },
+    itemBuried: {
+      kind: 'string',
+      variant: "radio",
+      label: "Item buried",
+      options: {
+        "Marbles": "Marbles",
+        "Food": "Food"
+      }
+    },
     additionalComments: {
       kind: "string",
       variant: "textarea",
@@ -38,7 +47,11 @@ export default defineInstrument({
       visibility: 'visible',
       ref: "roomNumber"
     },
-   
+    itemBuried: {
+      kind: 'const',
+      visibility: 'visible',
+      ref: "itemBuried"
+    },
     additionalComments: {
       kind: 'const',
       visibility: 'visible',
@@ -48,6 +61,7 @@ export default defineInstrument({
   },
   validationSchema: z.object({
     roomNumber: z.string(),
+    itemBuried: z.enum(["Marbles","Food"]),
     additionalComments: z.string().optional()
   })
 });

--- a/public/forms/CoBraLab-Burying-Task-form/index.ts
+++ b/public/forms/CoBraLab-Burying-Task-form/index.ts
@@ -3,6 +3,23 @@
 const { defineInstrument } = await import('/runtime/v1/@opendatacapture/runtime-core/index.js');
 const { z } = await import('/runtime/v1/zod@3.23.x/index.js');
 
+type BuryingItemType = "Food" | "Marbles"
+
+
+function createDependentField<const T>(field: T, fn: (buryingItemType?: BuryingItemType) => boolean) {
+  return {
+    kind: 'dynamic' as const,
+    deps: ['itemBuried'] as const,
+    render: (data: { itemBuried?: BuryingItemType }) => {
+      if (fn(data.itemBuried)) {
+        return field;
+      }
+      return null;
+    }
+  };
+}
+
+
 export default defineInstrument({
   kind: 'FORM',
   language: 'en',
@@ -26,6 +43,24 @@ export default defineInstrument({
         "Food": "Food"
       }
     },
+    cageNumber: createDependentField({
+      kind: 'string',
+      variant: "input",
+      label: "Cage number"
+    }, (type) => type === "Marbles"),
+    percentageMarblesBuried: createDependentField({
+      kind: 'string',
+            variant: "radio",
+            label: "Percentage range of marbles buried",
+            options: {
+              "100 %": "100 %",
+              "100 - 75%": "100 - 75%",
+              "75% - 0%":"75% - 0%"
+            }
+    },(type) => type === "Marbles"),
+
+
+
     additionalComments: {
       kind: "string",
       variant: "textarea",
@@ -62,6 +97,8 @@ export default defineInstrument({
   validationSchema: z.object({
     roomNumber: z.string(),
     itemBuried: z.enum(["Marbles","Food"]),
+    cageNumber: z.string().optional(),
+    percentageMarblesBuried: z.enum(["100 %","100 - 75%","75% - 0%"]).optional(),
     additionalComments: z.string().optional()
   })
 });

--- a/public/forms/CoBraLab-Burying-Task-form/index.ts
+++ b/public/forms/CoBraLab-Burying-Task-form/index.ts
@@ -59,8 +59,6 @@ export default defineInstrument({
             }
     },(type) => type === "Marbles"),
 
-
-
     additionalComments: {
       kind: "string",
       variant: "textarea",
@@ -86,6 +84,16 @@ export default defineInstrument({
       kind: 'const',
       visibility: 'visible',
       ref: "itemBuried"
+    },
+    cageNumber: {
+      kind: 'const',
+      visibility: 'visible',
+      ref: "cageNumber"
+    },
+    percentageMarblesBuried: {
+      kind: 'const',
+      visibility: 'visible',
+      ref: "percentageMarblesBuried"
     },
     additionalComments: {
       kind: 'const',


### PR DESCRIPTION
The pull requests works on issue #87 

Separated these tasks into their own type of form. 

Food burying section also has ethovision related question if used within the task. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated development configuration for improved dependency compatibility.
- **New Features**
  - Introduced a dynamic, user-friendly form for recording mouse behavioral experiment data, featuring conditional fields and robust validation to support precise data capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->