### PR TITLE
make n-generation question optional

### DIFF
--- a/public/forms/CoBraLab-Mouse-Origin-Form/index.ts
+++ b/public/forms/CoBraLab-Mouse-Origin-Form/index.ts
@@ -8,7 +8,7 @@ export default defineInstrument({
   language: 'en',
   tags: ['Birth', 'Mouse','Origin'],
   internal: {
-    edition: 3,
+    edition: 4,
     name: 'MOUSE_ORIGIN_FORM'
   },
   content: {
@@ -28,7 +28,7 @@ export default defineInstrument({
     cohortId: {
       kind: 'string',
       variant: 'input',
-      label: 'Cohort Identification (Optional)'
+      label: 'Cohort Identification (optional)'
     },
     mouseStrain: {
       kind: "string",
@@ -349,7 +349,7 @@ export default defineInstrument({
     generationNumber: {
       kind: 'number',
       variant: 'input',
-      label: 'N-generation of mouse'
+      label: 'N-generation of mouse (optional)'
     },
     additionalComments: {
       kind: "string",
@@ -575,7 +575,7 @@ export default defineInstrument({
   ]).optional(),
   otherBreederOrigin: z.string().optional(),
   roomNumber: z.string().optional(),
-  generationNumber: z.number().min(0).int(),
+  generationNumber: z.number().min(0).int().optional(),
   additionalComments: z.string().optional()
 })
 });


### PR DESCRIPTION
increments edition
makes N-generation optional
Adds `(optional)` tag to question

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated form field labels to clearly indicate which fields are optional
  * Changed the mouse generation field from required to optional, providing users more flexibility when completing the form
  * Standardized optional field label formatting for improved consistency across the form

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->