### PR TITLE
Change putbacks related questions in the motor task form

### DIFF
--- a/public/forms/CoBrALab-Mouse-Motor-Task-Form/index.ts
+++ b/public/forms/CoBrALab-Mouse-Motor-Task-Form/index.ts
@@ -73,8 +73,15 @@ export default defineInstrument({
 
     rotarodPutbacks: createDependentField({
       kind: "number",
-      variant: "input",
-      label: "Additional times put back on rotarod"
+      variant: "select",
+      label: "Additional times put back on rotarod",
+      options: {
+        0: 'None',
+        1: 'One time',
+        2: 'Two times',
+        3: 'Three times'
+      }
+      
     }, (type) => type === "Rotarod"),
 
    
@@ -87,8 +94,14 @@ export default defineInstrument({
 
     wirehangPutbacks: createDependentField({
       kind: "number",
-      variant: "input",
-      label: "Additional times put back on wire"
+      variant: "select",
+      label: "Additional times put back on wire",
+      options: {
+        0: 'None',
+        1: 'One time',
+        2: 'Two times',
+        3: 'Three times'
+      }
     },(type) => type === "Wire hang"),
 
     poleTestDuration: createDependentField({
@@ -229,10 +242,10 @@ export default defineInstrument({
     rotarodTotalMiceNumber: z.number().min(1).max(4).optional(),
     rotarodDuration: z.number().min(0).optional(),
     rotarodSlotPosition: z.enum(["Left most", "Middle left", "Middle right", "Right most"]).optional(),
-    rotarodPutbacks: z.number().int().min(0).optional(),
+    rotarodPutbacks: z.union([z.literal(0),z.literal(1), z.literal(2), z.literal(3)]).optional(),
     rotarodWirehangGripForceFailure: z.boolean().optional(),
     wirehangDuration: z.number().min(0).optional(),
-    wirehangPutbacks: z.number().min(0).int().optional(),
+    wirehangPutbacks: z.union([z.literal(0),z.literal(1), z.literal(2), z.literal(3)]).optional(),
     poleTestDuration: z.number().min(0).optional(),
     poleTestResultLevel: z.enum(["Pass", "Marginal failure", "Failure"]).optional(),
     poleTestMarginalFailureReason: z.string().optional(),


### PR DESCRIPTION
closes issue #121 

changes the question labels for the put back related questions

users now can select 4 options for each question (0,1,2,3) 

form can be seen [here ](https://playground.opendatacapture.org/?files=NobwRAxg9gdgLgU3mAXGA9AKgAQIM4A2AlvALQAmReAhgEYELYAOCATgGYIRxGxVzo8UVnFJRaAKy5w82TOgA6MJdBh442ENnIJ2JBAEk1cVgFcAtkg0BfbAF5s1AO7UiGouabC4ACgDk6GbwHgjoAG4AjOgAAlAsMOTUcNQQ1ExwpqyhQTyWpNBZ6CQ6AB4AdBJ4fgCUANwqsOqa2ABe2LYOzq7unt7%2BgabBluFRLVDk0QDMZQBM0yVFCQjllTX1yhtwAJ4s2ACyUHDCACrUeADW9tjYCmAASofUrOO32AA%2BN2AA6kRZ2AAW1BgAHNXh9bgAFKAMbCIdRgz4AcVYRCY2HYwggCFu6yU7EG3F4MGwECySQQABEEPEdPAAGJEBAEcgAHlUTWOAD4fHomeQUNhjgAadEwAU%2BcyHE5nc4AfgFByOrFOF2q9k52FoUGhCCBapASmuWQyrGJBuJ12w52KAr85C2MGo5iIED8jlk7LgQsNlp0TDwAuAfklSpV5z8AF13STGl6fUakDpWOLEskBVoQ9KLvL9lLlTL2mq7BrzZbLUR2NgeTAfKnqGVM-nVfr42XsMbMsTecz1m32q2EybiTBTAQCL3LdYfdZ1lONssvCJtLpqKONDo9DBDMYzJZ4D5S1abdg-HSAPJ3PZ%2Bb0WghA4GmajAhC2pDXn3JYEB7BBh7JZ7kNeJ6KsIsIylUIp%2BD8fwABL3kBfhQjCcJwAhyKouimIIJGN7XCQiCmtQBDpq2CCUDwsACjMuGWo6li2nsZ4AKoAMoAKIAPqMccF4cccACCLEANIceel5%2BNONGqIg8AkRaRrauYAByFi0Gwcl9taCQCrc6goiCtw0WWYRPEQQJwDpYAkEwphwIZA7YHeanEZ8DxQOY2AjuYamsLcrbWEZ2CNmGGltlp-KfHpJCgmAgXXCZKLmZZeBMtI9nyZaTlMpZIGsGBFzpX2cQUWooV9rcf5PC8qCuY8AGFX2nzQYwgIGTVtzNQC94NeVYBIYwKG3JZ-WwvgdmxQ51y3OhaIYqwWJDUiKKzVhfkZdcc7%2BYFzz-uMxyPAQewuggKneepJJkogVI0lYDJ8geDnhZZXk%2BT1loJWZsmRcQSZvdcWUubcp0%2BdgUCVs6WKg8SaRME8SSmLI5CZNFsL-IwECZFk8BBVACPYbIyQXFWJAQAQpiUCCON49Uf1BdQJQCgALHFQUkAKERbT42wsEWGrc4wdiC7Vu3kLc1Q3q2O1VeQFKZEkRIoKSupXdSia3YyzIPetR7aZ8L1sLTH1JZ81m2bTAOWbLrDy7Amq6MIjDsERxCUz4KWqOQeA02AnP87zsI7ALQsVXV1Xi0okuh%2BQLEEIcUJ4G4CsXcrlKq0s9Ia%2BQWuaceukmNFhumcbumpdw5t0NlwvS8wUAJyVtPFUS36Hr1AAyugaJK8LtWA7fsJ3tfjSzU1gEd5DkDCDD94ttxjxPjBT0Pk2fHPMIosC-zjTlRDj2vRAb0v2sj3c%2B%2Bbzj3eWSfB-n%2BNDlzmWAVVn76oB7sgsOCHItixLGVSwBEK2VoCkc434lbkmumrDO90W6WienrVSBsJrayNl9EuDAy5IL7BbT4-Fx6J1gERWEIRZA2Q0EAiAlxbZ-2qizRujQyptgAAy2iUrAbCw9sARFtGeLcRDLDviPtgGYtpjhOCgHw-AAjGrYEmCI-4WQBrEIktre%2BbYtpP0Dv7fm9hg73Cjt-CO8lWyticL8BArVgRWxtmKMBKsbpQM1jA64cDbj618pgtsKCLImxgKQ8uzlLKt1gM%2BJoSNrYlTtnNR2zsUZuy4LAT23tfaaJfto9%2BTUzFdTauHDYZZTFZAsQAuA5CQEClsanexcA7qOMernMAbjC6JVQWAFK6DD5YIroDMAuDyJEkIbkfAzBbKamAVDbA%2BTsQeLLHQ0qmhl7MJPKwrcUjGpcJPDwxR-COHCJPKI8RAyILL1kbs%2BRCBNmSLvsknmqTA46I-t8TJFiDG5MtF4BgxwxpWJKmUy6FTIFVMztnMKdSGlTPekXZppt2ltmwZCHUo1QlywiXEj2Xs1oPxFFzFJxZX5B3uSNQaYAcmtjeQgD56g7j4DXO3MIldykQPTgC6BtTdZ530jFFmXjkql2hWWWFfV4UoXbFSggvLLQzObsvSEZw8Azz6jK2mI89hPGBCQQhTsiBkyyK8FAs8VVqoIOiVwWrJkcNuHSY1mRJmWQtZqq16K2yqI2pi5%2BOK0m6IJWNZ5JKdTkrgMq1gqrHQEFtSaylZxKJzO1i4sA9o6Iulpn6b8wBbikr9ZSvA1KEC0oILcCMLMsZJlrEkagLZBEVmLckMoaaxoZqzTmu5K99XBqNXa7VRKnFtg7KaKN0iywxqim1DhxkIXeNuIgEo-5dSKphZ0y%2BuohBdlAuYZt6rLXtsMX2-sginVdoQEOTyo5c0qK2q2YEy06RYX4pKQY3j6Vp1pEympFoY2gpolynxfiPH8pmpheajAnS42xj4c9To0U%2BxgI-LF1y3W3PSdNZaf6FpEpotQ8gzULEzUvf%2B0NVqfkpwZY%2B6pWdO3OLqVqHUQIZ0ftuNbSgUAZ38oOHjVtDByDYBSngBOsAHUYo0TBvmcHdGVXqmAd4Hx3X3M6k8sTbwJNCfub%2BuayHiUZWoHgkqREADC7k9wyAYWR1lLT85DocjRsAE6p3UH8ZXW4PT8EtugOYPTsqIMP0kj6UmjJ4BUmSJqyVGUxoeHJDLJFScIiBRIHpUwhJ6E-luPtO26JNVsewCQcZaMty0rytQKmKUYyeAYHCRwOMlT5XOGUbABh3CyAXNIMiqMkio0YI2crHH8DcehrIJwTJDVnGa7CbUhq8bsZ8CJ8YIpPXqBFBMrJwIRTnowsphAaoqBWhgFAJwMAyh5o8xaHQfmCABbLDoPApJUTfJPNhjyRxlxnZRGpbQJbsDAiSGjLI7H0u5ZvSlBQCg-CyFa4TS4dWUR6ZWf9Y6agXwnn4rDCAaNSAzDKIwiHRC4AMAYrjfLuVBQymUc6n0lgzhWuO5aZ47lgbnU7TGz0hsqBEFoJqtwWxLJhAZ-QU1DksjsEshT5SCD3GnoysFGUBmdYRVuHTsF8UOfM%2B2GzjnDBaY88sqLgqbnJzbSjvtZIh1jpU%2BTL24FRnpecrl8QBXnx2cJ05yr3QfOdcHSOliQ3vH2ja5Fl8pONO6lm7MxblnivbfK5l8K3nnw0Pe545rwnv8o4xzjrXBz4vaexnp7b%2BXrPrdK659rVXkeE%2BxzgPHBz7uAqRxFkUkpZP%2B1%2B-T2Hm3jOs-B8Z6HgtDvC9V8AcA1zwvK-Sww-eLDWFcNZFT-X4wGfm%2BW%2Bz7cJvduw8F9o1HIfIIR84fXZM4XeSzEWOj2KY3dfTcN-N5n2frfF8d4j7cCZ%2B%2Bwsx535aO-95q%2B94nyfqfjfA9W-n7n%2B3N%2BYAL%2BIIb%2BFCfeGUFeGUNa6gB%2BH%2BkukAp%2BAe5%2BQeOeIeeefYy%2BYA0BcAB%2B5egU2BdaoqNKlcvun%2B3cZ%2BM%2BKBf%2BaBABlkBBIqcAxBuaseHuPq7yY0AaQaREY%2BCA4ai6cBlk-uyCP%2Bc%2BYAC%2B7e3OneqavqHBq6IaW%2BfBj%2BEBgUi2TA2GWI16QG3ipB8BQhfYC%2BLeqBbe6Be6gBqh6hCAmht6eBm6lo6mvSBCBAOmzmVgtesCk%2B5BSBlBv%2BYh-%2BS%2BUhYA9hDm2mumrh5ee28UREO81iLECOCAK6AoLQZQ4gUg3AQKCklOguiRZQg6wIPgOSZY6u5w2RSAFgPgKaeiX8YmIoHUjy3U1RnwU2Q8S0S2q0YAEYBR5OTueuLuJ0WRrQZQbi%2BRDYJAPgEQ1QDY9MPgjMExMyRE%2BRnu0ssBAxQxExzoNYjCsx6QfSBACxA%2BAEieJeyel2SRpR5g5RtwfcA85BK8O888jkHchktxu8jA68m8TxFUp81x40HRyR2xjhex8e3exS7%2BAxgwRI5RSRlubA8xmxQoUJbgMJux4xIoCJBE8xMw4sAx0J1suxkw1QvxcxuxnRCkIsa%2BwIG%2BWIPB2RFGDAQIwxRJgJu%2BBS94yxSRqxIxGxWxmmxJgUwBwIoBpSYJMAEJwAaJSJPgcJ4puJYxWJ0pGJcpZQOJ8x%2BJhJ-xwaTJryMhMBD%2Bh%2B7Jguwx6xkp3JOxmp1w9BmaRB2alcpxXkFx8qXGHxo8chrG9qsUnwPBeaJpAJJJNc7B6gnBBqPBihepORJmeR3pGpvp5hV6N6X0%2BpZ0rAhpox4xfxPJZpjgGmOxzhLm2RuRDJ6p8xNMFo1gxZpZ6wsU9SToCAqAVkSw5QMgYA1gEYQAA&label=LYewLiBOC0YIYGcDW0BmVhA)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Replaced manual entry fields with dropdown menus for 'Additional times put back on rotarod' and 'Additional times put back on wire,' offering standardized options: None, One time, Two times, or Three times.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->